### PR TITLE
OrderedGroup should exit early if any of the started members exit

### DIFF
--- a/grouper/dynamic_group_test.go
+++ b/grouper/dynamic_group_test.go
@@ -126,7 +126,9 @@ var _ = Describe("dynamicGroup", func() {
 			exit2, exit3 := grouper.ExitEvent{}, grouper.ExitEvent{}
 
 			childRunner1.TriggerReady()
+			time.Sleep(time.Millisecond)
 			childRunner2.TriggerReady()
+			time.Sleep(time.Millisecond)
 			childRunner3.TriggerReady()
 			time.Sleep(time.Millisecond)
 
@@ -141,7 +143,9 @@ var _ = Describe("dynamicGroup", func() {
 			Consistently(entrances).ShouldNot(Receive())
 
 			childRunner1.TriggerExit(nil)
+			time.Sleep(time.Millisecond)
 			childRunner2.TriggerExit(nil)
+			time.Sleep(time.Millisecond)
 			childRunner3.TriggerExit(nil)
 			time.Sleep(time.Millisecond)
 

--- a/grouper/ordered_test.go
+++ b/grouper/ordered_test.go
@@ -170,6 +170,28 @@ var _ = Describe("Ordered Group", func() {
 			})
 		})
 
+		Describe("when the first member is started", func() {
+			var signals <-chan os.Signal
+
+			BeforeEach(func() {
+				childRunner1.WaitForCall()
+				childRunner1.TriggerReady()
+			})
+
+			Describe("and the first member exits while second member is setting up", func() {
+				BeforeEach(func() {
+					signals = childRunner2.WaitForCall()
+					childRunner1.TriggerExit(nil)
+				})
+
+				It("should terminate", func() {
+					var signal os.Signal
+					Eventually(signals).Should(Receive(&signal))
+					Expect(signal).To(Equal(syscall.SIGINT))
+				})
+			})
+		})
+
 		Describe("Failed start", func() {
 			BeforeEach(func() {
 				signal1 := childRunner1.WaitForCall()


### PR DESCRIPTION
Prior to this change OrderedGroup won't listen on the exit signals from other members in the group during initialization. Only the member that is currently initializing could cause the group to shutdown.
