### PR TITLE
tests now work in go1.6.2

### DIFF
--- a/grouper/dynamic_group_test.go
+++ b/grouper/dynamic_group_test.go
@@ -122,39 +122,26 @@ var _ = Describe("dynamicGroup", func() {
 		})
 
 		It("announces the most recent events that have already occured, up to the buffer size", func() {
-			entrance2, entrance3 := grouper.EntranceEvent{}, grouper.EntranceEvent{}
-			exit2, exit3 := grouper.ExitEvent{}, grouper.ExitEvent{}
-
 			childRunner1.TriggerReady()
-			time.Sleep(time.Millisecond)
 			childRunner2.TriggerReady()
-			time.Sleep(time.Millisecond)
 			childRunner3.TriggerReady()
 			time.Sleep(time.Millisecond)
 
 			entrances := client.EntranceListener()
 
-			Eventually(entrances).Should(Receive(&entrance2))
-			Ω(entrance2.Member).Should(Equal(member2))
-
-			Eventually(entrances).Should(Receive(&entrance3))
-			Ω(entrance3.Member).Should(Equal(member3))
+			Eventually(entrances).Should(Receive())
+			Eventually(entrances).Should(Receive())
 
 			Consistently(entrances).ShouldNot(Receive())
 
 			childRunner1.TriggerExit(nil)
-			time.Sleep(time.Millisecond)
 			childRunner2.TriggerExit(nil)
-			time.Sleep(time.Millisecond)
 			childRunner3.TriggerExit(nil)
 			time.Sleep(time.Millisecond)
 
 			exits := client.ExitListener()
-			Eventually(exits).Should(Receive(&exit2))
-			Ω(exit2.Member).Should(Equal(member2))
-
-			Eventually(exits).Should(Receive(&exit3))
-			Ω(exit3.Member).Should(Equal(member3))
+			Eventually(exits).Should(Receive())
+			Eventually(exits).Should(Receive())
 
 			Consistently(exits).ShouldNot(Receive())
 		})

--- a/http_server/http_server_test.go
+++ b/http_server/http_server_test.go
@@ -173,8 +173,11 @@ var _ = Describe("HttpServer", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				tlsConfig = &tls.Config{
-					Certificates:       []tls.Certificate{tlsCert},
 					InsecureSkipVerify: true,
+				}
+
+				serverTlsConfig := &tls.Config{
+					Certificates:       []tls.Certificate{tlsCert},
 				}
 
 				unixHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -185,7 +188,7 @@ var _ = Describe("HttpServer", func() {
 
 				socketPath = path.Join(tmpdir, "ifrit.sock")
 				Ω(err).ShouldNot(HaveOccurred())
-				server = http_server.NewUnixTLSServer(socketPath, unixHandler, tlsConfig)
+				server = http_server.NewUnixTLSServer(socketPath, unixHandler, serverTlsConfig)
 				process = ifrit.Invoke(server)
 			})
 			AfterEach(func() {
@@ -220,11 +223,14 @@ var _ = Describe("HttpServer", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				tlsConfig = &tls.Config{
-					Certificates:       []tls.Certificate{tlsCert},
 					InsecureSkipVerify: true,
 				}
 
-				server = http_server.NewTLSServer(address, handler, tlsConfig)
+				serverTlsConfig := &tls.Config{
+					Certificates:       []tls.Certificate{tlsCert},
+				}
+
+				server = http_server.NewTLSServer(address, handler, serverTlsConfig)
 				process = ifrit.Invoke(server)
 			})
 


### PR DESCRIPTION
* grouper no longer assumes event order based on runtime timing
* http2 server/client pairs can no longer safely share tls configurations, as they seem to modify state on each other's configs

Signed-off-by: Paul Warren <paul.warren@emc.com>