### PR TITLE
Expose session.Err on ginkgomon.Runner

### DIFF
--- a/ginkgomon/ginkgomon.go
+++ b/ginkgomon/ginkgomon.go
@@ -80,6 +80,16 @@ func (r *Runner) Buffer() *gbytes.Buffer {
 	return r.session.Buffer()
 }
 
+// Err returns the gbytes.Buffer associated with the stderr stream.
+// For use with the gbytes.Say matcher.
+func (r *Runner) Err() *gbytes.Buffer {
+	if r.sessionReady == nil {
+		ginkgo.Fail(fmt.Sprintf("ginkgomon.Runner '%s' improperly created without using New", r.Name))
+	}
+	<-r.sessionReady
+	return r.session.Err
+}
+
 func (r *Runner) Run(sigChan <-chan os.Signal, ready chan<- struct{}) error {
 	defer ginkgo.GinkgoRecover()
 


### PR DESCRIPTION
I need to make some assertions on output from stderr and found that the runner doesn't expose the stream.  #14 requests similar functionality and you seemed amenable to a PR.

Instead of exposing the gexec.Session, this change exports the Err buffer. Happy to change it to expose the whole session if you'd prefer but this gave me what I needed.

Thanks.