### PR TITLE
Print a more meaningful error

### DIFF
--- a/ginkgomon/ginkgomon.go
+++ b/ginkgomon/ginkgomon.go
@@ -112,7 +112,7 @@ func (r *Runner) Run(sigChan <-chan os.Signal, ready chan<- struct{}) error {
 		),
 	)
 
-	Ω(err).ShouldNot(HaveOccurred())
+	Ω(err).ShouldNot(HaveOccurred(), fmt.Sprintf("%s failed to start with err: %s", r.Name, err))
 
 	fmt.Fprintf(debugWriter, "spawned %s (pid: %d)\n", r.Command.Path, r.Command.Process.Pid)
 


### PR DESCRIPTION
Instead of:

      Expected error:
          <*os.PathError | 0xc4206bf380>: {Op: "fork/exec", Path: "", Err: 0x2}
          fork/exec : no such file or directory
      not to have occurred

ginkgomon will now print the following:

      route-emitter-0 failed to start with err: fork/exec : no such file or directory
      Expected error:
          <*os.PathError | 0xc4206bf380>: {Op: "fork/exec", Path: "", Err: 0x2}
          fork/exec : no such file or directory
      not to have occurred

Signed-off-by: Sunjay Bhatia <sbhatia@pivotal.io>