### PR TITLE
Fix go1.11 vet error for unused variable

### DIFF
--- a/grouper/ordered_test.go
+++ b/grouper/ordered_test.go
@@ -90,13 +90,12 @@ var _ = Describe("Ordered Group", func() {
 
 		Describe("when all the runners are ready", func() {
 			var (
-				signal1 <-chan os.Signal
 				signal2 <-chan os.Signal
 				signal3 <-chan os.Signal
 			)
 
 			BeforeEach(func() {
-				signal1 = childRunner1.WaitForCall()
+				childRunner1.WaitForCall()
 				childRunner1.TriggerReady()
 				signal2 = childRunner2.WaitForCall()
 				childRunner2.TriggerReady()


### PR DESCRIPTION
Go 1.11 complains about `signal1` being unused, this change removes just removes the variable but keeps the rest of the test setup the same