### PR TITLE
Fixed wrong package name in go.mod.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ifrit
+module github.com/tedsuo/ifrit
 
 go 1.16
 


### PR DESCRIPTION
@tedsuo Sorry I made a mistake with package name in my last PR. The `go.mod` file was auto generated, and I didn't notice the wrong package name. Today when I tried to bump the version in Concourse, it failed then I noticed this mistake.